### PR TITLE
Synchronize access to static counter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>ST4</artifactId>
 	<packaging>jar</packaging>
 
-	<version>4.0.9-SNAPSHOT</version>
+	<version>4.0.9-RMSPatch</version>
 
 	<name>StringTemplate 4</name>
 	<description>StringTemplate is a java template engine for generating source code,

--- a/src/org/stringtemplate/v4/compiler/Compiler.java
+++ b/src/org/stringtemplate/v4/compiler/Compiler.java
@@ -187,7 +187,7 @@ public class Compiler {
 		return blank;
 	}
 
-	public static String getNewSubtemplateName() {
+	public synchronized static String getNewSubtemplateName() {
 		subtemplateCount++;
 		return SUBTEMPLATE_PREFIX+subtemplateCount;
 	}


### PR DESCRIPTION
@cgeorge-rms @ffomenko-rms @smoradi-rms 

When called many (100s of thousands) times from multiple threads, `getNewSubtemplateName()` can return the same value twice in a particular thread, due to race condition on accessing the static int `subtemplateCount`.  

This can lead to the ST() constructor seeing two distinct subtemplates with the same name, causing `Redefinition of template SUBTEMPLATE` error message to be printed. In some cases, this name conflict can cause corruption of the merged template.  

During import, the corrupted string is saved as the merged CDL. When this is passed to the CDL parser for indexing later in the import process,  a CDL compilation error is raised and the import fails (RAE-22149).

Solution is to synchronize the `getNewSubtemplateName()` method.  
Deployment: this should be pushed to our Artifactory, and shaded by ProductMerge.
Care should be taken that consumers actually use this version of ST4, since the official version 4.0.8 is compiled into the antlr-4.5 jar.

Testing: A simple unit test is at https://github.com/RMS/fm/blob/stgroup-redefinition-diagnosis/product-merge/src/test/scala/com/rms/cdl/product/TestManyThreadsProductMerge.scala:

```
it should "run lots of times in parallel" in {
    val poolSize = 4
    val pool: ExecutorService = Executors.newFixedThreadPool(poolSize)
    for (i <- 1 to 500000) {
      pool.execute(new Runner())

    }
    pool.shutdown()
    pool.awaitTermination(600, TimeUnit.SECONDS)
  }


  class Runner() extends Runnable {

    def run() = {
      //println( "Thread " + Thread.currentThread().getName )
      val template = singleRiskPoliicy
      val actualCdl = ProductMerge(template).merge(instance)
      trim(expected) should equal(trim(actualCdl))
    }

  }
```
This was run dozens of times prior to the fix, causing the `redefinition...` message in >90% of the runs, and corruption of the string about 10% of the time. 
After the fix was applied, the unit test was upped to 800K iterations and run 5 times with no errors.


